### PR TITLE
Implement custom Uno rules and initial test setup

### DIFF
--- a/uno_game/__init__.py
+++ b/uno_game/__init__.py
@@ -1,0 +1,4 @@
+# This file makes 'uno_game' a top-level package.
+# You can define a version or import key modules here if desired.
+
+__version__ = "0.1.0"

--- a/uno_game/src/__init__.py
+++ b/uno_game/src/__init__.py
@@ -1,0 +1,9 @@
+# This file makes the src directory a Python package.
+
+# Optionally, make key classes available when importing src
+from .card import Card, Color, Rank
+from .deck import Deck
+from .player import Player
+from .game import UnoGame
+
+__all__ = ['Card', 'Color', 'Rank', 'Deck', 'Player', 'UnoGame']

--- a/uno_game/src/actions.py
+++ b/uno_game/src/actions.py
@@ -1,0 +1,105 @@
+from enum import Enum, auto
+from typing import Optional, Any
+from .card import Color # For chosen_color
+
+class ActionType(Enum):
+    # Standard game flow
+    NEXT_PLAYER = auto()
+    REVERSE_DIRECTION = auto()
+    SKIP_PLAYER = auto()
+
+    # Drawing cards
+    DRAW_CARDS = auto() # value = number of cards, target = next player by default
+
+    # Wild card related
+    CHOOSE_COLOR = auto() # Player who played the wild needs to choose
+
+    # Custom rules
+    SWAP_CARD_RIGHT = auto() # Player needs to choose card to give, and one to receive
+    SWAP_CARD_ANY = auto()   # Player needs to choose card to give, target player, and card to receive
+    DISCARD_FROM_PLAYER_HAND = auto() # Target player (player to left) discards 2 cards from current player's hand (chosen by target)
+    PLAYER_DRAWS_FOUR_UNLESS_LAST = auto() # Player who played it draws 4, unless it's their last card
+    PLAY_ANY_AND_DRAW_ONE = auto() # Player plays any card, then draws one
+    TAKE_RANDOM_FROM_PREVIOUS = auto()
+    PLACE_TOP_DRAW_PILE_CARD = auto() # Places draw pile's top card onto discard; its effect applies
+    DISCARD_ALL_TWOS = auto() # Player who played duplicate discards all their 2s.
+
+    # Meta/Game state
+    GAME_WIN = auto()
+    CONTINUE_TURN = auto() # For when a player gets to play again (e.g. after Rank 9 places a matching card)
+    NOP = auto() # No operation, simple turn pass after card play.
+
+
+class GameAction:
+    def __init__(self, action_type: ActionType, value: Any = None, target_player_offset: Optional[int] = None, message: str = ""):
+        self.type = action_type
+        self.value = value  # e.g., number of cards to draw, chosen color, specific cards for swap
+        self.target_player_offset = target_player_offset # e.g., 1 for next player, -1 for previous, 0 for current
+        self.message_override = message # Optional message to use instead of a default one
+
+    def __repr__(self):
+        return f"GameAction({self.type.name}, value={self.value}, target_offset={self.target_player_offset})"
+
+    @staticmethod
+    def card_played_message(player_name: str, card_str: str, uno_shouted: bool):
+        msg = f"{player_name} played {card_str}."
+        if uno_shouted:
+            msg += f" {player_name} shouts UNO!"
+        return msg
+
+
+# Example of how this might be used:
+# if card.rank == Rank.DRAW_TWO:
+# return [GameAction(ActionType.DRAW_CARDS, value=2, target_player_offset=1), GameAction(ActionType.SKIP_PLAYER, target_player_offset=1)]
+# if card.rank == Rank.WILD:
+# return [GameAction(ActionType.CHOOSE_COLOR)] # This would likely be a preliminary action before other effects
+
+# For Rank 7 (Swap with right):
+# This will be complex as it requires multiple steps of player input.
+# 1. Initial play of 7: Game notes SWAP_CARD_RIGHT is pending.
+# 2. Game prompts current player: "Choose a card from your hand to give."
+# 3. Game prompts current player: "Choose a card from player X's hand to take." (Player X is to the right)
+# Or, if non-interactive, these choices are made randomly/strategically.
+
+# For now, when _apply_card_effect sees a Rank 7, it will simply return GameAction(ActionType.SWAP_CARD_RIGHT).
+# The main game loop will then need a handler for SWAP_CARD_RIGHT that contains the logic for these choices.
+# This makes _apply_card_effect a dispatcher for effects rather than an executor of all of them.
+# The play_turn method will then interpret these actions.
+# Some actions are immediate (like REVERSE_DIRECTION), others set up next step (like CHOOSE_COLOR or SWAP_CARD_RIGHT).
+# Some actions might target the *next* player (DRAW_CARDS, SKIP_PLAYER).
+# play_turn returns a list of messages and potentially a "next_state" for the game if it needs more input.
+# Or, play_turn itself becomes a state machine.
+# Let's make play_turn handle the immediate consequences and setup for multi-step actions.
+# _apply_card_effect will return a list of GameAction objects.
+# play_turn will iterate through them.
+# If an action requires more input (like choosing a card for swap), play_turn might return a special status
+# indicating more input is needed from the same player.
+
+# Color counters will also be handled. When a card is played, its color increments a counter for the player.
+# This can be done directly in play_turn after a card is successfully played.
+# Yellow -- 1 coin
+# Green -- 1 shuffle
+# Blue -- 1 lunar mana
+# Red -- 1 solar mana
+# These are awarded to the player who *played* the card.
+# Wild cards, when played, do not award these specific color counters, as their played color is chosen
+# and isn't one of the four basic elements. If a Wild is played and (e.g.) BLUE is chosen,
+# it does not grant lunar mana. Only naturally Blue cards grant lunar mana.
+# This needs to be clarified if my assumption is wrong. Assuming it's for playing R,Y,G,B non-Wild cards.
+
+# Let's confirm: Does playing a "Wild, chosen Blue" count for Blue mana?
+# For now, I'll assume NO: only intrinsic Red, Yellow, Green, Blue cards grant their respective counters.
+# The rules state "Each color played adds a counter", which could imply the chosen color of a Wild.
+# User clarified: "The color triangle does not have any other gameplay effect." - this doesn't directly answer the Wild counter question.
+# "Color Elements: Fire-water-grass triangle... Yellow is neutral. Each color played adds a counter"
+# This suggests the *actual color on the card face*. So a Wild card (which is Color.WILD) would not grant these.
+# I will proceed with this assumption: Wilds do not grant these specific R,Y,G,B counters.
+# The "Yellow 4" get out of jail free pile is separate.
+
+# Shuffle counter mechanic:
+# "If the draw pile is empty and a player needs to draw a card, they must use a shuffle counter
+# to shuffle the discard pile into a new draw pile. If they don't have a shuffle counter,
+# they can't draw and must skip their turn... If no one has shuffle counters and the draw pile is empty,
+# the player who needs to draw skips their turn."
+# This will be integrated into `_handle_draw_pile_empty`.
+pass # Placeholder for actual file content creation using the tool

--- a/uno_game/src/card.py
+++ b/uno_game/src/card.py
@@ -1,0 +1,154 @@
+from enum import Enum, auto
+
+class Color(Enum):
+    RED = auto()
+    YELLOW = auto()
+    GREEN = auto()
+    BLUE = auto()
+    WILD = auto()  # For Wild and Wild Draw Four
+
+    def __str__(self):
+        return self.name
+
+class Rank(Enum):
+    ZERO = 0
+    ONE = 1
+    TWO = 2
+    THREE = 3
+    FOUR = 4
+    FIVE = 5
+    SIX = 6
+    SEVEN = 7
+    EIGHT = 8
+    NINE = 9
+    DRAW_TWO = 10
+    SKIP = 11
+    REVERSE = 12
+    WILD = 13
+    WILD_DRAW_FOUR = 14
+
+    def __str__(self):
+        if self.value < 10:
+            return str(self.value)
+        return self.name
+
+class Card:
+    def __init__(self, color: Color, rank: Rank):
+        if not isinstance(color, Color):
+            raise TypeError("Color must be an instance of Color Enum")
+        if not isinstance(rank, Rank):
+            raise TypeError("Rank must be an instance of Rank Enum")
+
+        # Wild cards should have the color WILD
+        if rank in [Rank.WILD, Rank.WILD_DRAW_FOUR]:
+            if color != Color.WILD:
+                # Automatically set color to WILD for these ranks if a specific color was provided
+                color = Color.WILD
+        # Non-wild cards should not have the color WILD
+        elif color == Color.WILD and rank not in [Rank.WILD, Rank.WILD_DRAW_FOUR]:
+            raise ValueError(f"Non-special rank {rank} cannot have color WILD")
+
+        self.color = color
+        self.rank = rank
+        self.active_color = color # For Wild cards, this will be set when played
+
+    def __str__(self):
+        if self.rank == Rank.WILD or self.rank == Rank.WILD_DRAW_FOUR:
+            if self.active_color != Color.WILD:
+                return f"WILD ({self.active_color.name})"
+            return f"{self.rank.name}" # e.g. WILD, WILD_DRAW_FOUR
+        return f"{self.color.name} {self.rank}"
+
+    def __repr__(self):
+        return f"Card({self.color.name}, {self.rank.name})"
+
+    def __eq__(self, other):
+        if not isinstance(other, Card):
+            return NotImplemented
+        return self.color == other.color and self.rank == other.rank
+
+    def __hash__(self):
+        return hash((self.color, self.rank))
+
+    def is_special_action(self) -> bool:
+        """Checks if the card is an action card (Skip, Reverse, Draw Two)."""
+        return self.rank in [Rank.DRAW_TWO, Rank.SKIP, Rank.REVERSE]
+
+    def is_wild(self) -> bool:
+        """Checks if the card is a Wild or Wild Draw Four."""
+        return self.rank in [Rank.WILD, Rank.WILD_DRAW_FOUR]
+
+    def matches(self, other_card, current_color_chosen_for_wild: Color = None) -> bool:
+        """
+        Checks if this card can be played on top of other_card.
+        current_color_chosen_for_wild is the color chosen if other_card is a Wild card.
+        """
+        if self.is_wild(): # Wild cards can be played on anything
+            return True
+        if other_card.is_wild():
+            # If the other card is wild, this card must match the chosen active color
+            return self.color == current_color_chosen_for_wild
+        # Standard match: color or rank
+        return self.color == other_card.color or self.rank == other_card.rank
+
+if __name__ == '__main__':
+    # Test basic card creation
+    red_seven = Card(Color.RED, Rank.SEVEN)
+    print(red_seven)
+
+    blue_skip = Card(Color.BLUE, Rank.SKIP)
+    print(blue_skip)
+
+    wild_card = Card(Color.WILD, Rank.WILD)
+    print(wild_card)
+    wild_card.active_color = Color.GREEN # Player chooses green
+    print(wild_card)
+
+    wild_d4 = Card(Color.WILD, Rank.WILD_DRAW_FOUR)
+    print(wild_d4)
+
+    # Test matching
+    red_five = Card(Color.RED, Rank.FIVE)
+    print(f"RED SEVEN matches RED FIVE? {red_seven.matches(red_five)}") # True (color)
+    blue_seven = Card(Color.BLUE, Rank.SEVEN)
+    print(f"RED SEVEN matches BLUE SEVEN? {red_seven.matches(blue_seven)}") # True (rank)
+    print(f"RED FIVE matches BLUE SEVEN? {red_five.matches(blue_seven)}") # False
+
+    # Test matching with wild
+    wild_card_on_table = Card(Color.WILD, Rank.WILD)
+    # wild_card_on_table.active_color = Color.BLUE # Imagine player chose BLUE for the wild
+    print(f"RED FIVE matches WILD (active BLUE)? {red_five.matches(wild_card_on_table, Color.BLUE)}") # False
+    blue_card = Card(Color.BLUE, Rank.ONE)
+    print(f"BLUE ONE matches WILD (active BLUE)? {blue_card.matches(wild_card_on_table, Color.BLUE)}") # True
+
+    # Test playing a wild card
+    print(f"WILD card matches RED FIVE? {wild_card.matches(red_five)}") # True
+
+    # Test error conditions
+    try:
+        Card(Color.RED, Rank.WILD) # Should correct to Color.WILD
+        # This should not raise error, it auto-corrects
+        card_auto_correct = Card(Color.RED, Rank.WILD)
+        assert card_auto_correct.color == Color.WILD
+        print("Auto-correction for Wild card color: PASS")
+    except ValueError as e:
+        print(f"Error test: {e}") # Should not happen
+
+    try:
+        Card(Color.WILD, Rank.SEVEN) # Should raise error
+    except ValueError as e:
+        print(f"Error test for non-wild rank with WILD color: {e}")
+
+    try:
+        Card("RED", Rank.SEVEN)
+    except TypeError as e:
+        print(f"Error test for invalid color type: {e}")
+
+    c1 = Card(Color.RED, Rank.ONE)
+    c2 = Card(Color.RED, Rank.ONE)
+    c3 = Card(Color.BLUE, Rank.ONE)
+    card_set = {c1, c2, c3}
+    print(f"Set of cards: {card_set}") # Should contain 2 cards
+    assert len(card_set) == 2
+
+    print("Card class tests completed.")

--- a/uno_game/src/deck.py
+++ b/uno_game/src/deck.py
@@ -1,0 +1,169 @@
+import random
+from typing import List, Optional
+from .card import Card, Color, Rank # Use absolute import based on common project structures
+
+class Deck:
+    def __init__(self, empty: bool = False):
+        self.cards: List[Card] = []
+        self.discard_pile: List[Card] = []
+        if not empty:
+            self.create_standard_deck()
+            self.shuffle()
+
+    def create_standard_deck(self):
+        """
+        Creates a standard Uno deck.
+        - 19 of each color (Red, Yellow, Green, Blue): 1x Zero, 2x One-Nine
+        - 8 Draw Two (2 of each color)
+        - 8 Reverse (2 of each color)
+        - 8 Skip (2 of each color)
+        - 4 Wild cards
+        - 4 Wild Draw Four cards
+        Total: 108 cards
+        """
+        self.cards = []
+        colors = [Color.RED, Color.YELLOW, Color.GREEN, Color.BLUE]
+
+        for color in colors:
+            # One Zero card
+            self.cards.append(Card(color, Rank.ZERO))
+            # Two of each number card 1-9
+            for i in range(1, 10):
+                rank = Rank(i)
+                self.cards.append(Card(color, rank))
+                self.cards.append(Card(color, rank))
+            # Two of each action card
+            for rank_action in [Rank.DRAW_TWO, Rank.SKIP, Rank.REVERSE]:
+                self.cards.append(Card(color, rank_action))
+                self.cards.append(Card(color, rank_action))
+
+        # Wild cards
+        for _ in range(4):
+            self.cards.append(Card(Color.WILD, Rank.WILD))
+            self.cards.append(Card(Color.WILD, Rank.WILD_DRAW_FOUR))
+
+        # print(f"Deck created with {len(self.cards)} cards.") # For debugging
+
+    def shuffle(self):
+        """Shuffles the main draw pile."""
+        random.shuffle(self.cards)
+
+    def draw_card(self) -> Optional[Card]:
+        """Draws a card from the top of the deck."""
+        if not self.cards:
+            return None  # Or raise an exception, or handle reshuffling here
+        return self.cards.pop()
+
+    def add_to_discard(self, card: Card):
+        """Adds a card to the top of the discard pile."""
+        if not isinstance(card, Card):
+            raise TypeError("Can only add Card objects to discard pile.")
+        self.discard_pile.append(card)
+
+    def get_top_discard_card(self) -> Optional[Card]:
+        """Returns the top card of the discard pile without removing it."""
+        if not self.discard_pile:
+            return None
+        return self.discard_pile[-1]
+
+    def is_empty(self) -> bool:
+        """Checks if the draw pile is empty."""
+        return not self.cards
+
+    def needs_reshuffle(self) -> bool:
+        """Checks if the draw pile is empty and the discard pile has cards."""
+        return self.is_empty() and bool(self.discard_pile)
+
+    def reshuffle_discard_pile_into_deck(self, keep_top_card: bool = True) -> bool:
+        """
+        Reshuffles the discard pile (except the top card, usually) into the draw pile.
+        Returns True if reshuffle happened, False otherwise.
+        """
+        if not self.discard_pile:
+            return False
+
+        top_card = None
+        if keep_top_card and self.discard_pile:
+            top_card = self.discard_pile.pop() # Keep the current top card on discard
+
+        self.cards.extend(self.discard_pile)
+        self.discard_pile = []
+        if top_card:
+            self.discard_pile.append(top_card) # Put the top card back
+
+        self.shuffle()
+        # print(f"Reshuffled. Draw pile: {len(self.cards)}, Discard pile: {len(self.discard_pile)}")
+        return True
+
+    def __len__(self):
+        """Returns the number of cards in the draw pile."""
+        return len(self.cards)
+
+if __name__ == '__main__':
+    deck = Deck()
+    print(f"Initial deck size: {len(deck)}")
+
+    # Test drawing cards
+    drawn_cards = []
+    for _ in range(10):
+        card = deck.draw_card()
+        if card:
+            drawn_cards.append(card)
+            deck.add_to_discard(card) # Add drawn card to discard
+        else:
+            print("Deck is empty!")
+            break
+
+    print(f"Drawn cards: {[str(c) for c in drawn_cards]}")
+    print(f"Deck size after drawing 10: {len(deck)}")
+    print(f"Discard pile size: {len(deck.discard_pile)}")
+    print(f"Top discard: {deck.get_top_discard_card()}")
+
+    # Test reshuffle
+    # Draw all cards to force a reshuffle scenario
+    while not deck.is_empty():
+        card = deck.draw_card()
+        if card:
+            deck.add_to_discard(card) # Simulate playing cards
+
+    print(f"Deck empty. Draw pile: {len(deck)}, Discard pile: {len(deck.discard_pile)}")
+
+    if deck.needs_reshuffle():
+        print("Deck needs reshuffle.")
+        # Simulate drawing when empty - game logic would handle this
+        # For now, manually trigger reshuffle
+        if deck.reshuffle_discard_pile_into_deck():
+            print("Reshuffle successful.")
+        else:
+            print("Reshuffle failed (no cards in discard).")
+
+    print(f"Deck size after reshuffle: {len(deck)}")
+    print(f"Discard pile size after reshuffle: {len(deck.discard_pile)}") # Should be 1
+    if deck.discard_pile:
+        print(f"Top discard after reshuffle: {str(deck.get_top_discard_card())}")
+
+    # Test drawing again
+    card = deck.draw_card()
+    print(f"Drew one more card: {card}")
+    print(f"Deck size: {len(deck)}")
+
+    # Test creating an empty deck
+    empty_deck = Deck(empty=True)
+    print(f"Empty deck size: {len(empty_deck)}")
+    print(f"Empty deck discard size: {len(empty_deck.discard_pile)}")
+    card = empty_deck.draw_card()
+    assert card is None
+    print("Empty deck tests completed.")
+
+    # Verify deck composition (simple check for total cards)
+    full_deck = Deck()
+    assert len(full_deck) == 108, f"Expected 108 cards, got {len(full_deck)}"
+    print("Deck composition count check: PASS")
+
+    # Test adding non-card to discard
+    try:
+        deck.add_to_discard("not a card")
+    except TypeError as e:
+        print(f"Error adding non-card to discard: {e}")
+
+    print("Deck class tests completed.")

--- a/uno_game/src/game.py
+++ b/uno_game/src/game.py
@@ -1,0 +1,792 @@
+from typing import List, Optional, Tuple
+import random
+
+from .card import Card, Color, Rank
+from .deck import Deck
+from .player import Player
+from .actions import ActionType, GameAction
+
+class UnoGame:
+    def __init__(self, player_names: List[str], initial_hand_size: int = 7):
+        if not 2 <= len(player_names) <= 4:
+            raise ValueError("UnoGame requires 2 to 4 players.")
+        if initial_hand_size <= 0:
+            raise ValueError("Initial hand size must be positive.")
+
+        self.deck = Deck()
+        self.players: List[Player] = [Player(name) for name in player_names]
+        self.initial_hand_size = initial_hand_size
+
+        self.current_player_index: int = 0
+        self.game_over: bool = False
+        self.winner: Optional[Player] = None
+        self.play_direction: int = 1
+
+        self.current_wild_color: Optional[Color] = None
+        self.pending_action: Optional[GameAction] = None
+        self.action_data: dict = {}
+
+        self._setup_game()
+
+    def _setup_game(self):
+        for _ in range(self.initial_hand_size):
+            for player in self.players:
+                card = self.deck.draw_card()
+                if card:
+                    player.add_card_to_hand(card)
+                else:
+                    raise RuntimeError("Deck ran out of cards during initial deal.")
+
+        first_discard = self.deck.draw_card()
+        while first_discard is None or first_discard.rank == Rank.WILD_DRAW_FOUR:
+            if first_discard:
+                self.deck.cards.append(first_discard)
+                self.deck.shuffle()
+            first_discard = self.deck.draw_card()
+            if first_discard is None and self.deck.needs_reshuffle():
+                 self.deck.reshuffle_discard_pile_into_deck(keep_top_card=False)
+                 first_discard = self.deck.draw_card()
+            elif first_discard is None:
+                 raise RuntimeError("Deck ran out of cards setting up discard pile.")
+
+        self.deck.add_to_discard(first_discard)
+        self.current_wild_color = None
+
+        self.current_player_index = random.randint(0, len(self.players) - 1)
+
+        if first_discard.is_wild():
+            chosen_color = random.choice([c for c in Color if c != Color.WILD])
+            self.current_wild_color = chosen_color
+            first_discard.active_color = chosen_color
+            print(f"Game starts with a Wild card. System chose {chosen_color.name} as the active color.")
+
+        # Note: Effects of the very first card (like Draw 2, Skip, Reverse) on the first player
+        # are complex and typically subject to house rules. This basic setup doesn't fully enact them.
+        # A robust implementation would handle this state before the first player's actual turn.
+        if first_discard.rank in [Rank.DRAW_TWO, Rank.SKIP, Rank.REVERSE] and not first_discard.is_wild():
+             print(f"Warning: Game started with an action card: {first_discard}. Its effect on the first player is not fully implemented in this basic setup phase.")
+
+    def get_current_player(self) -> Player:
+        return self.players[self.current_player_index]
+
+    def get_top_card(self) -> Optional[Card]:
+        return self.deck.get_top_discard_card()
+
+    def _get_player_at_offset(self, base_player_idx: int, offset: int) -> Player:
+        # Calculates player index considering play direction and offset.
+        # Note: offset is usually 1 for next, -1 for previous *in current direction*.
+        # If offset is an absolute direction (e.g. -1 always means left), then play_direction isn't used here.
+        # For GameActions, target_player_offset often implies direction already.
+        target_idx = (base_player_idx + offset + len(self.players)) % len(self.players)
+        return self.players[target_idx]
+
+    def _advance_turn_marker(self, steps=1):
+        self.current_player_index = (self.current_player_index + self.play_direction * steps) % len(self.players)
+
+    def _handle_draw_pile_empty(self, drawing_player: Player) -> bool:
+        if self.deck.needs_reshuffle():
+            if drawing_player.shuffle_counters > 0:
+                drawing_player.shuffle_counters -= 1
+                print(f"{drawing_player.name} uses a shuffle counter ({drawing_player.shuffle_counters} remaining). Reshuffling discard pile...")
+                self.deck.reshuffle_discard_pile_into_deck()
+                if self.deck.is_empty():
+                    print("Draw pile is still empty after reshuffle. No cards to draw.")
+                    return False
+            else:
+                print(f"{drawing_player.name} needs to draw, draw pile empty, but has no shuffle counters. Draw is skipped.")
+                return False
+        elif self.deck.is_empty():
+            print("Draw pile is empty and no cards in discard to reshuffle. No cards to draw.")
+            return False
+        return True
+
+    def player_draws_card(self, player: Player, count: int = 1) -> List[Card]:
+        drawn_cards: List[Card] = []
+        for i in range(count):
+            can_draw = self._handle_draw_pile_empty(player)
+            if not can_draw: break
+            card = self.deck.draw_card()
+            if card: player.add_card_to_hand(card); drawn_cards.append(card)
+            else: print(f"Warning: {player.name} tried to draw, but no card was available after check."); break
+        return drawn_cards
+
+    def _get_card_actions(self, card: Card, playing_player: Player, chosen_color_for_wild: Optional[Color] = None) -> List[GameAction]:
+        actions: List[GameAction] = []
+        player_name = playing_player.name
+        player_idx = self.players.index(playing_player)
+
+        if card.rank == Rank.SEVEN:
+            actions.append(GameAction(ActionType.SWAP_CARD_RIGHT, message=f"{player_name} plays {card}, triggers card swap with player to the right."))
+        elif card.rank == Rank.ZERO:
+            actions.append(GameAction(ActionType.SWAP_CARD_ANY, message=f"{player_name} plays {card}, triggers card swap with any player."))
+        elif card.color == Color.BLUE and card.rank == Rank.THREE:
+            actions.append(GameAction(ActionType.DISCARD_FROM_PLAYER_HAND, target_player_offset=-self.play_direction,
+                                      value={'count': 2, 'from_player_idx': player_idx}, # from_player_idx is who played Blue3
+                                      message=f"{player_name} plays {card}. Player to the left must discard 2 cards from {player_name}'s hand."))
+        elif card.color == Color.RED and card.rank == Rank.EIGHT:
+            # Hand size check is for player who played the card, *after* it's played.
+            # If hand_size > 0 means Red 8 was not their last card.
+            if playing_player.hand_size() > 0:
+                actions.append(GameAction(ActionType.PLAYER_DRAWS_FOUR_UNLESS_LAST, target_player_offset=0, # Target is self
+                                           message=f"{player_name} plays {card} and draws 4 cards."))
+            else:
+                actions.append(GameAction(ActionType.NOP, message=f"{player_name} plays {card} as their last card. No draw effect."))
+        elif card.rank == Rank.SIX:
+            actions.append(GameAction(ActionType.PLAY_ANY_AND_DRAW_ONE, target_player_offset=0,
+                                       message=f"{player_name} plays {card}. They can play any card next, then draw one."))
+        elif card.color == Color.GREEN and card.rank == Rank.FIVE:
+            actions.append(GameAction(ActionType.TAKE_RANDOM_FROM_PREVIOUS, target_player_offset=-self.play_direction,
+                                       message=f"{player_name} plays {card} and takes a random card from the previous player."))
+        elif card.rank == Rank.NINE:
+            actions.append(GameAction(ActionType.PLACE_TOP_DRAW_PILE_CARD, message=f"{player_name} plays {card}. Top card from draw pile will be played."))
+
+        # Rank 2 (discard all 2s on duplicate) is handled in play_turn directly, not as a GameAction from here.
+
+        is_custom_effect_handled = any(a.type not in [ActionType.NOP, ActionType.CHOOSE_COLOR] for a in actions)
+
+        if not is_custom_effect_handled: # Standard Uno actions if not overridden
+            if card.is_wild():
+                # If chosen_color_for_wild is already provided (e.g. by AI or UI), use it.
+                # Otherwise, CHOOSE_COLOR action signals the need for input.
+                if chosen_color_for_wild:
+                     actions.append(GameAction(ActionType.CHOOSE_COLOR, value=chosen_color_for_wild,
+                                               message_override=f"{player_name} chose {chosen_color_for_wild.name}."))
+                else:
+                     actions.append(GameAction(ActionType.CHOOSE_COLOR, value=None, message_override="Wild played, color must be chosen."))
+
+                if card.rank == Rank.WILD_DRAW_FOUR:
+                    actions.append(GameAction(ActionType.DRAW_CARDS, value=4, target_player_offset=1, message=f"Next player draws 4 cards."))
+                    actions.append(GameAction(ActionType.SKIP_PLAYER, target_player_offset=1, message="and is skipped."))
+            elif card.rank == Rank.DRAW_TWO:
+                actions.append(GameAction(ActionType.DRAW_CARDS, value=2, target_player_offset=1, message=f"Next player draws 2 cards."))
+                actions.append(GameAction(ActionType.SKIP_PLAYER, target_player_offset=1, message="and is skipped."))
+            elif card.rank == Rank.SKIP:
+                actions.append(GameAction(ActionType.SKIP_PLAYER, target_player_offset=1, message=f"Next player is skipped."))
+            elif card.rank == Rank.REVERSE:
+                actions.append(GameAction(ActionType.REVERSE_DIRECTION, message="Play direction reversed."))
+                if len(self.players) == 2: actions.append(GameAction(ActionType.SKIP_PLAYER, target_player_offset=0, message="Acts like a Skip in a 2-player game."))
+
+        if not actions: actions.append(GameAction(ActionType.NOP, message=""))
+        return actions
+
+    def _award_color_counters(self, player: Player, card: Card):
+        if card.color == Color.RED: player.solar_mana += 1; print(f"{player.name} gained 1 Solar Mana (Total: {player.solar_mana}).")
+        elif card.color == Color.YELLOW:
+            player.coins += 1; print(f"{player.name} gained 1 Coin (Total: {player.coins}).")
+            if card.rank == Rank.FOUR:
+                if player.store_yellow_4_get_out_of_jail(card): print(f"{player.name}'s Yellow 4 moved to 'get out of jail free' pile.")
+                else: print(f"{player.name} already has Yellow 4 stored.")
+        elif card.color == Color.GREEN: player.shuffle_counters += 1; print(f"{player.name} gained 1 Shuffle Counter (Total: {player.shuffle_counters}).")
+        elif card.color == Color.BLUE: player.lunar_mana += 1; print(f"{player.name} gained 1 Lunar Mana (Total: {player.lunar_mana}).")
+
+    def play_turn(self, player: Player, card_index: Optional[int],
+                  action_input: Optional[dict] = None,
+                  chosen_color_for_wild: Optional[Color] = None) -> Tuple[bool, str, Optional[ActionType]]:
+        current_turn_player_obj = self.get_current_player()
+
+        if self.pending_action is None and player != current_turn_player_obj:
+            return False, "It's not your turn.", None
+        if self.game_over:
+            return False, "The game is already over.", None
+
+        message_parts = []
+        next_action_needed: Optional[ActionType] = None
+
+        # --- Part 1: Handle pending multi-step actions ---
+        if self.pending_action:
+            actor_for_pending = player # Player passed to this call is the one acting on the pending item.
+            original_initiator_idx = self.action_data.get('original_player_idx', self.players.index(current_turn_player_obj))
+            original_initiator = self.players[original_initiator_idx]
+
+            if self.pending_action.type == ActionType.SWAP_CARD_RIGHT:
+                if actor_for_pending != original_initiator: return False, "Not your turn for SWAP_CARD_RIGHT.", None
+                # ... (SWAP_CARD_RIGHT logic as before, using actor_for_pending and original_initiator_idx for context) ...
+                player_to_right = self._get_player_at_offset(original_initiator_idx, self.play_direction)
+                card_to_give_idx = action_input.get('card_to_give_idx') if action_input else None
+                card_to_take_idx = action_input.get('card_to_take_idx') if action_input else None
+                if card_to_give_idx is None or card_to_take_idx is None: return False, "Card choices missing for swap.", ActionType.SWAP_CARD_RIGHT
+                if not (0 <= card_to_give_idx < actor_for_pending.hand_size()): return False, f"Invalid card index to give.", ActionType.SWAP_CARD_RIGHT
+                if player_to_right.is_hand_empty(): message_parts.append(f"{player_to_right.name}'s hand empty, swap cancelled.")
+                elif not (0 <= card_to_take_idx < player_to_right.hand_size()): return False, f"Invalid card index to take.", ActionType.SWAP_CARD_RIGHT
+                else:
+                    card_given = actor_for_pending.play_card(card_to_give_idx)
+                    card_taken = player_to_right.play_card(card_to_take_idx)
+                    if card_given and card_taken:
+                        actor_for_pending.add_card_to_hand(card_taken); player_to_right.add_card_to_hand(card_given)
+                        message_parts.append(f"{actor_for_pending.name} gave {card_given} to {player_to_right.name}, took {card_taken}.")
+                    else:
+                        if card_given: actor_for_pending.add_card_to_hand(card_given)
+                        if card_taken: player_to_right.add_card_to_hand(card_taken)
+                        message_parts.append("Error in Rank 7 swap.")
+                self.pending_action = None; self.action_data.clear(); self.current_player_index = original_initiator_idx; self._advance_turn_marker()
+                return True, " ".join(filter(None, message_parts)), None
+
+            elif self.pending_action.type == ActionType.SWAP_CARD_ANY:
+                if actor_for_pending != original_initiator: return False, "Not your turn for SWAP_CARD_ANY.", None
+                if 'target_player_idx' not in self.action_data:
+                    target_idx_input = action_input.get('target_player_idx') if action_input else None
+                    if target_idx_input is None or not (0 <= target_idx_input < len(self.players)) or target_idx_input == original_initiator_idx:
+                        return False, "Invalid target player for Rank 0 swap.", ActionType.SWAP_CARD_ANY
+                    self.action_data['target_player_idx'] = target_idx_input
+                    message_parts.append(f"{actor_for_pending.name} targets {self.players[target_idx_input].name}.")
+                    return True, " ".join(filter(None, message_parts)) + " Now choose cards.", ActionType.SWAP_CARD_ANY
+
+                target_player = self.players[self.action_data['target_player_idx']]
+                card_to_give_idx = action_input.get('card_to_give_idx') if action_input else None
+                card_to_take_idx = action_input.get('card_to_take_idx') if action_input else None
+                if card_to_give_idx is None or card_to_take_idx is None: return False, "Card choices missing.", ActionType.SWAP_CARD_ANY
+                if not (0 <= card_to_give_idx < actor_for_pending.hand_size()): return False, f"Invalid card idx to give.", ActionType.SWAP_CARD_ANY
+                if target_player.is_hand_empty(): message_parts.append(f"{target_player.name} hand empty, swap cancelled.")
+                elif not (0 <= card_to_take_idx < target_player.hand_size()): return False, f"Invalid card idx to take.", ActionType.SWAP_CARD_ANY
+                else:
+                    card_given = actor_for_pending.play_card(card_to_give_idx); card_taken = target_player.play_card(card_to_take_idx)
+                    if card_given and card_taken:
+                        actor_for_pending.add_card_to_hand(card_taken); target_player.add_card_to_hand(card_given)
+                        message_parts.append(f"{actor_for_pending.name} gave {card_given} to {target_player.name}, took {card_taken}.")
+                    else:
+                        if card_given: actor_for_pending.add_card_to_hand(card_given)
+                        if card_taken: target_player.add_card_to_hand(card_taken)
+                        message_parts.append("Error in Rank 0 swap.")
+                self.pending_action = None; self.action_data.clear(); self.current_player_index = original_initiator_idx; self._advance_turn_marker()
+                return True, " ".join(filter(None, message_parts)), None
+
+            elif self.pending_action.type == ActionType.DISCARD_FROM_PLAYER_HAND:
+                chooser = actor_for_pending
+                victim_idx = self.action_data.get('victim_idx')
+                expected_chooser_idx = self.action_data.get('chooser_idx')
+                num_to_discard = self.action_data.get('count', 2)
+                original_blue3_player_idx = self.action_data.get('original_player_idx', victim_idx)
+
+                if victim_idx is None or expected_chooser_idx is None or self.players.index(chooser) != expected_chooser_idx:
+                    return False, "Error: Mismatch in DISCARD_FROM_PLAYER_HAND context.", None
+                victim = self.players[victim_idx]
+                chosen_indices = action_input.get('chosen_indices_from_victim', []) if action_input else []
+
+                actual_to_discard_count = min(num_to_discard, victim.hand_size())
+                if not isinstance(chosen_indices, list) or len(set(chosen_indices)) != actual_to_discard_count:
+                     return False, f"{chooser.name} must choose {actual_to_discard_count} distinct cards.", ActionType.DISCARD_FROM_PLAYER_HAND
+
+                chosen_indices.sort(reverse=True)
+                discarded_cards_str = []
+                actually_discarded_cards_objects = []
+                valid_indices = True
+                for idx_to_pop in chosen_indices:
+                    if not (0 <= idx_to_pop < victim.hand_size()): valid_indices=False; break
+                    card_obj = victim.play_card(idx_to_pop)
+                    if card_obj: actually_discarded_cards_objects.append(card_obj)
+                    else: valid_indices = False; break
+
+                if not valid_indices:
+                    for c_obj in actually_discarded_cards_objects: victim.add_card_to_hand(c_obj) # Rollback
+                    return False, "Error processing chosen discard indices.", ActionType.DISCARD_FROM_PLAYER_HAND
+
+                for card_obj in actually_discarded_cards_objects:
+                     self.deck.add_to_discard(card_obj); discarded_cards_str.append(str(card_obj))
+                message_parts.append(f"{chooser.name} made {victim.name} discard: {', '.join(discarded_cards_str)}.")
+
+                self.pending_action = None; self.action_data.clear()
+                self.current_player_index = original_blue3_player_idx
+                self._advance_turn_marker()
+                return True, " ".join(filter(None, message_parts)), None
+
+            elif self.pending_action.type == ActionType.PLAY_ANY_AND_DRAW_ONE:
+                player_of_rank_6 = original_initiator
+                if actor_for_pending != player_of_rank_6: return False, "Not your turn for Rank 6 effect.", None
+                card_idx_for_effect = card_index
+                color_for_wild_effect = action_input.get('chosen_color_for_rank_6_wild') if action_input else None
+
+                if card_idx_for_effect is None: return False, "Must choose card for Rank 6.", ActionType.PLAY_ANY_AND_DRAW_ONE
+                if not (0 <= card_idx_for_effect < player_of_rank_6.hand_size()): return False, "Invalid card index for Rank 6.", ActionType.PLAY_ANY_AND_DRAW_ONE
+
+                card_to_play_freely = player_of_rank_6.hand[card_idx_for_effect]
+                if card_to_play_freely.is_wild() and color_for_wild_effect is None:
+                    self.action_data['is_for_rank_6_wild'] = True
+                    self.action_data['rank_6_card_idx_pending_color'] = card_idx_for_effect
+                    self.action_data['original_player_idx'] = self.players.index(player_of_rank_6)
+                    self.pending_action = GameAction(ActionType.CHOOSE_COLOR)
+                    return True, f"{player_of_rank_6.name} chose Wild {card_to_play_freely} for Rank 6. Choose color.", ActionType.CHOOSE_COLOR
+
+                played_card_for_rank_6 = player_of_rank_6.play_card(card_idx_for_effect)
+                message_parts.append(f"{player_of_rank_6.name} (Rank 6) plays {played_card_for_rank_6} freely.")
+                self.deck.add_to_discard(played_card_for_rank_6)
+
+                active_color_for_effects = None
+                if played_card_for_rank_6.is_wild():
+                    if color_for_wild_effect is None: return False, "Logic Error: Rank 6 Wild color missing.", None
+                    self.current_wild_color = color_for_wild_effect; played_card_for_rank_6.active_color = color_for_wild_effect
+                    active_color_for_effects = color_for_wild_effect; message_parts.append(f"Color chosen: {color_for_wild_effect.name}.")
+                else: self.current_wild_color = None; active_color_for_effects = played_card_for_rank_6.color
+
+                self._award_color_counters(player_of_rank_6, played_card_for_rank_6)
+                actions_from_freely_played = self._get_card_actions(played_card_for_rank_6, player_of_rank_6, active_color_for_effects)
+
+                skip_after_freely_played = False
+                for item_action in actions_from_freely_played:
+                    if item_action.message_override: message_parts.append(item_action.message_override)
+                    if item_action.type == ActionType.GAME_WIN: self.game_over=True; self.winner=player_of_rank_6; break
+                    if item_action.type == ActionType.DRAW_CARDS:
+                        t_offset = item_action.target_player_offset if item_action.target_player_offset is not None else 1
+                        victim = self._get_player_at_offset(original_initiator_idx, self.play_direction * t_offset)
+                        self.player_draws_card(victim, item_action.value)
+                    if item_action.type == ActionType.SKIP_PLAYER: skip_after_freely_played = True
+                    if item_action.type == ActionType.REVERSE_DIRECTION: self.play_direction *= -1
+                if self.game_over: return True, " ".join(filter(None,message_parts)), None
+
+                message_parts.append(f"{player_of_rank_6.name} draws 1 card (Rank 6).")
+                self.player_draws_card(player_of_rank_6, 1)
+                self.pending_action = None; self.action_data.clear()
+                self.current_player_index = original_initiator_idx; self._advance_turn_marker()
+                if skip_after_freely_played: message_parts.append(f"{self.get_current_player().name} skipped."); self._advance_turn_marker()
+                return True, " ".join(filter(None,message_parts)), None
+
+            elif self.pending_action.type == ActionType.CHOOSE_COLOR:
+                chosen_color_input = action_input.get('chosen_color') if action_input else None
+                if not isinstance(chosen_color_input, Color) or chosen_color_input == Color.WILD:
+                    return False, "Invalid color for Wild.", ActionType.CHOOSE_COLOR
+
+                if self.action_data.get('is_for_rank_6_wild'):
+                    rank_6_card_idx = self.action_data.pop('rank_6_card_idx_pending_color')
+                    self.action_data.pop('is_for_rank_6_wild')
+                    player_for_rank_6_idx = self.action_data.get('original_player_idx', self.players.index(actor_for_pending))
+                    player_for_rank_6 = self.players[player_for_rank_6_idx]
+                    message_parts.append(f"{player_for_rank_6.name} chose {chosen_color_input.name} for Rank 6 Wild.")
+                    self.pending_action = GameAction(ActionType.PLAY_ANY_AND_DRAW_ONE)
+                    return self.play_turn(player_for_rank_6, card_index=rank_6_card_idx, action_input={'chosen_color_for_rank_6_wild': chosen_color_input})
+                else:
+                    card_that_was_wild = self.action_data.get('card_played')
+                    player_who_chose_idx = self.action_data.get('player_idx', self.players.index(actor_for_pending))
+                    player_who_chose = self.players[player_who_chose_idx]
+                    if not card_that_was_wild: return False, "Error: CHOOSE_COLOR context missing.", None
+
+                    self.current_wild_color = chosen_color_input; card_that_was_wild.active_color = chosen_color_input
+                    message_parts.append(f"{player_who_chose.name} chose {chosen_color_input.name} for {card_that_was_wild}.")
+                    remaining_actions = self.action_data.pop('remaining_actions', [])
+                    self.pending_action = None; self.action_data.clear()
+                    skip_after_wild = False
+                    for rem_action in remaining_actions:
+                        if rem_action.message_override: message_parts.append(rem_action.message_override)
+                        if rem_action.type == ActionType.DRAW_CARDS:
+                            t_offset = rem_action.target_player_offset if rem_action.target_player_offset is not None else 1
+                            victim = self._get_player_at_offset(player_who_chose_idx, self.play_direction * t_offset)
+                            self.player_draws_card(victim, rem_action.value)
+                        if rem_action.type == ActionType.SKIP_PLAYER: skip_after_wild = True
+
+                    self.current_player_index = player_who_chose_idx; self._advance_turn_marker()
+                    if skip_after_wild: message_parts.append(f"{self.get_current_player().name} skipped."); self._advance_turn_marker()
+                    return True, " ".join(filter(None,message_parts)), None
+
+        # --- Part 2: Standard card play (if no pending_action was handled) ---
+        # Player here is current_turn_player_obj for a new play.
+        if card_index is None: return False, "No card played or pending action.", None
+        if not (0 <= card_index < player.hand_size()): return False, "Invalid card index.", None
+
+        card_to_play_peek = player.hand[card_index]
+        top_discard = self.get_top_card()
+        if not top_discard: return False, "Error: No card on discard pile.", None
+
+        if not card_to_play_peek.matches(top_discard, self.current_wild_color):
+            return False, f"Cannot play {card_to_play_peek} on {top_discard} (Active: {self.current_wild_color}).", None
+
+        played_card = player.play_card(card_index)
+        if not played_card: return False, "Error retrieving card.", None
+
+        message_parts.append(GameAction.card_played_message(player.name, str(played_card), player.hand_size() == 1))
+
+        # --- Handle Rank 2 duplicate rule ---
+        # This check happens *after* card is played and *before* its own actions are fetched.
+        card_underneath = self.deck.get_top_discard_card() # Card that was top before this play
+        self.deck.add_to_discard(played_card) # Now played_card is on top
+
+        if card_underneath and \
+           played_card.rank == card_underneath.rank and \
+           played_card.color == card_underneath.color: # It's a duplicate play
+            twos_in_hand = [c for c in player.hand if c.rank == Rank.TWO]
+            if twos_in_hand:
+                message_parts.append(f"{player.name} played a duplicate {played_card}! Discarding all 2s.")
+                for two_card in twos_in_hand:
+                    player.remove_card_from_hand(two_card)
+                    self.deck.add_to_discard(two_card) # 2s go to discard
+                    message_parts.append(f"{player.name} discards {two_card}.")
+                if player.is_hand_empty(): # Win by discarding last 2s
+                    self.game_over = True; self.winner = player
+                    message_parts.append(f" {player.name} wins by discarding last 2s after duplicate play!")
+                    return True, " ".join(filter(None, message_parts)), None
+
+        if not played_card.is_wild(): self.current_wild_color = None
+        self._award_color_counters(player, played_card)
+
+        # If chosen_color_for_wild was None for a Wild card, _get_card_actions will return CHOOSE_COLOR action.
+        actions_to_process = self._get_card_actions(played_card, player, chosen_color_for_wild if played_card.is_wild() else None)
+
+        if player.is_hand_empty() and not any(a.type == ActionType.GAME_WIN for a in actions_to_process):
+            actions_to_process = [GameAction(ActionType.GAME_WIN)]
+
+        # --- Part 3: Process actions from the just-played card ---
+        skip_next_player_flag = False
+        advance_turn_normally = True
+        action_idx = 0
+        while action_idx < len(actions_to_process):
+            action = actions_to_process[action_idx]; action_idx +=1
+            if action.message_override: message_parts.append(action.message_override)
+
+            if action.type == ActionType.GAME_WIN:
+                self.game_over = True; self.winner = player
+                message_parts.append(f" {player.name} wins the game!")
+                return True, " ".join(filter(None, message_parts)), None
+            elif action.type == ActionType.CHOOSE_COLOR:
+                if action.value:
+                    self.current_wild_color = action.value
+                    if played_card and played_card.is_wild(): played_card.active_color = action.value
+                else:
+                    self.pending_action = action
+                    self.action_data = {'card_played': played_card, 'remaining_actions': actions_to_process[action_idx:], 'player_idx': self.players.index(player), 'original_player_idx': self.players.index(player)}
+                    return True, " ".join(filter(None, message_parts)) + f" {player.name} needs to choose color.", ActionType.CHOOSE_COLOR
+            elif action.type == ActionType.DRAW_CARDS:
+                t_offset = action.target_player_offset if action.target_player_offset is not None else 1
+                victim = self._get_player_at_offset(self.players.index(player), self.play_direction * t_offset)
+                self.player_draws_card(victim, action.value)
+            elif action.type == ActionType.SKIP_PLAYER: skip_next_player_flag = True
+            elif action.type == ActionType.REVERSE_DIRECTION: self.play_direction *= -1
+            elif action.type in [ActionType.SWAP_CARD_RIGHT, ActionType.SWAP_CARD_ANY, ActionType.DISCARD_FROM_PLAYER_HAND, ActionType.PLAY_ANY_AND_DRAW_ONE]:
+                self.pending_action = action
+                self.action_data = {'original_card': played_card, 'remaining_actions': actions_to_process[action_idx:], 'original_player_idx': self.players.index(player)}
+                # Specific data for each type
+                if action.type == ActionType.DISCARD_FROM_PLAYER_HAND:
+                    self.action_data['chooser_idx'] = self.players.index(self._get_player_at_offset(self.players.index(player), self.play_direction * action.target_player_offset))
+                    self.action_data['victim_idx'] = self.players.index(player) # Who played Blue 3
+                    self.action_data['count'] = action.value['count']
+                # For SWAP_CARD_RIGHT/ANY, PLAY_ANY_AND_DRAW_ONE, 'original_player_idx' is who initiated.
+                next_action_needed = action.type
+                advance_turn_normally = False; break
+            elif action.type == ActionType.PLAYER_DRAWS_FOUR_UNLESS_LAST:
+                self.player_draws_card(player, 4)
+            elif action.type == ActionType.TAKE_RANDOM_FROM_PREVIOUS:
+                prev_player_idx = (self.players.index(player) - self.play_direction + len(self.players)) % len(self.players)
+                previous_player = self.players[prev_player_idx]
+                if not previous_player.is_hand_empty():
+                    card_to_take = random.choice(previous_player.hand)
+                    removed_card = previous_player.remove_card_from_hand(card_to_take)
+                    if removed_card: player.add_card_to_hand(removed_card); message_parts.append(f"{player.name} took {removed_card} from {previous_player.name} (Green 5).")
+                    else: message_parts.append(f"Error taking card from {previous_player.name} for Green 5.")
+                else: message_parts.append(f"{previous_player.name}'s hand is empty for Green 5.")
+            elif action.type == ActionType.PLACE_TOP_DRAW_PILE_CARD: # Rank 9
+                if not self._handle_draw_pile_empty(player):
+                    message_parts.append("Rank 9: Draw pile empty, no card to place.")
+                else:
+                    new_top_card = self.deck.draw_card()
+                    if new_top_card:
+                        message_parts.append(f"Rank 9 places {new_top_card} from draw pile.")
+                        self.deck.add_to_discard(new_top_card)
+                        if not new_top_card.is_wild(): self.current_wild_color = None
+
+                        new_card_sub_actions = self._get_card_actions(new_top_card, player, None) # Player who played 9 chooses color if new is Wild
+                        temp_skip_for_rank9_card = False
+                        rank9_card_ends_turn = False
+
+                        for sub_a in new_card_sub_actions: # Process sub-actions
+                            if sub_a.message_override: message_parts.append(f"({new_top_card}): {sub_a.message_override}")
+                            if sub_a.type == ActionType.CHOOSE_COLOR:
+                                if sub_a.value: self.current_wild_color = sub_a.value; new_top_card.active_color = sub_a.value
+                                else: # Rank 9 placed a Wild, current player needs to choose
+                                    self.pending_action = sub_a
+                                    self.action_data = {'card_played': new_top_card, 'player_idx': self.players.index(player), 'original_player_idx': self.players.index(player)}
+                                    next_action_needed = ActionType.CHOOSE_COLOR; advance_turn_normally=False; rank9_card_ends_turn=True; break
+                            elif sub_a.type == ActionType.DRAW_CARDS:
+                                t_offset_sub = sub_a.target_player_offset if sub_a.target_player_offset is not None else 1
+                                victim_sub = self._get_player_at_offset(self.players.index(player), self.play_direction * t_offset_sub)
+                                self.player_draws_card(victim_sub, sub_a.value)
+                                if t_offset_sub == 1: rank9_card_ends_turn = True # If it's a Draw affecting next player
+                            elif sub_a.type == ActionType.SKIP_PLAYER: temp_skip_for_rank9_card = True; rank9_card_ends_turn = True
+                            elif sub_a.type == ActionType.REVERSE_DIRECTION:
+                                self.play_direction *= -1
+                                if len(self.players) == 2: temp_skip_for_rank9_card = True; rank9_card_ends_turn = True
+                                # else, for >2p, if player can play on new card, turn might not end.
+
+                        if next_action_needed == ActionType.CHOOSE_COLOR: break # Break outer loop for CHOOSE_COLOR
+
+                        if rank9_card_ends_turn:
+                            skip_next_player_flag = temp_skip_for_rank9_card # If Rank 9 card caused skip
+                        elif player.has_playable_card(new_top_card, self.current_wild_color): # Player can play on new card
+                            message_parts.append(f"{player.name} may play again on {new_top_card}.")
+                            advance_turn_normally = False # Player's turn continues
+                        else: # Cannot play on new card
+                             message_parts.append(f"{player.name} cannot play on {new_top_card}. Turn ends.")
+                             advance_turn_normally = True # Ensure turn advances
+                    else: message_parts.append("Rank 9: Failed to draw card.")
+            elif action.type == ActionType.NOP: pass
+
+        if self.game_over: return True, " ".join(filter(None, message_parts)), None
+        if next_action_needed: return True, " ".join(filter(None, message_parts)), next_action_needed
+
+        if advance_turn_normally:
+            self.current_player_index = self.players.index(player)
+            self._advance_turn_marker()
+            if skip_next_player_flag:
+                message_parts.append(f"{self.get_current_player().name}'s turn is skipped.")
+                self._advance_turn_marker()
+        return True, " ".join(filter(None, message_parts)), None
+
+    def player_cannot_play_action(self, player: Player) -> Tuple[bool, str]:
+        # ... (rest of the class and __main__ block remains the same as the last successful overwrite)
+        # This method needs to be robust to pending actions too.
+        current_turn_player = self.get_current_player()
+        if player != current_turn_player: return False, "It's not your turn."
+        if self.game_over: return False, "The game is already over."
+
+        actor_for_pending_input = player # By default, current player
+        if self.pending_action:
+            if self.pending_action.type == ActionType.DISCARD_FROM_PLAYER_HAND:
+                actor_for_pending_input = self.players[self.action_data.get('chooser_idx', self.players.index(player))]
+            elif self.pending_action.type in [ActionType.SWAP_CARD_RIGHT, ActionType.SWAP_CARD_ANY, ActionType.PLAY_ANY_AND_DRAW_ONE, ActionType.CHOOSE_COLOR]:
+                 actor_idx = self.action_data.get('original_player_idx', self.action_data.get('player_idx', self.players.index(player)))
+                 actor_for_pending_input = self.players[actor_idx]
+
+        if self.pending_action and actor_for_pending_input == player :
+             return False, f"Cannot 'draw card' while pending action '{self.pending_action.type.name}' requires your input."
+
+        message_parts = [f"{player.name} cannot play, so they draw a card."]
+        drawn_cards = self.player_draws_card(player, 1)
+
+        if not drawn_cards:
+            message_parts.append("No card was drawn. Turn passes.")
+            self.current_player_index = self.players.index(player)
+            self._advance_turn_marker()
+            return True, " ".join(message_parts)
+
+        drawn_card = drawn_cards[0]
+        message_parts.append(f"{player.name} drew {drawn_card}.")
+
+        top_discard = self.get_top_card()
+        # Player may play the drawn card if it's playable (standard Uno).
+        if top_discard and drawn_card.matches(top_discard, self.current_wild_color):
+            message_parts.append(f"The drawn card ({drawn_card}) is playable.")
+            # Simulate auto-playing it for now
+            player.remove_card_from_hand(drawn_card)
+
+            chosen_color_for_drawn_wild = None
+            active_color_after_drawn_play = None
+            if drawn_card.is_wild():
+                chosen_color_for_drawn_wild = random.choice([c for c in Color if c != Color.WILD])
+                message_parts.append(f"{player.name} chose {chosen_color_for_drawn_wild.name} for the drawn Wild.")
+                active_color_after_drawn_play = chosen_color_for_drawn_wild
+            else:
+                active_color_after_drawn_play = drawn_card.color
+
+            message_parts.append(GameAction.card_played_message(player.name, f"drawn {drawn_card}", player.hand_size() == 1))
+
+            self.deck.add_to_discard(drawn_card)
+            if not drawn_card.is_wild(): self.current_wild_color = None
+            elif chosen_color_for_drawn_wild:
+                self.current_wild_color = chosen_color_for_drawn_wild
+                drawn_card.active_color = chosen_color_for_drawn_wild
+
+            self._award_color_counters(player, drawn_card)
+
+            if player.is_hand_empty():
+                self.game_over = True; self.winner = player
+                message_parts.append(f" {player.name} played their last card ({drawn_card}) and wins!")
+                return True, " ".join(filter(None, message_parts))
+
+            actions_from_drawn = self._get_card_actions(drawn_card, player, active_color_after_drawn_play)
+            skip_after_drawn = False
+            for action in actions_from_drawn:
+                if action.message_override: message_parts.append(action.message_override)
+                if action.type == ActionType.GAME_WIN: self.game_over=True; self.winner=player; break
+                if action.type == ActionType.DRAW_CARDS:
+                    t_offset = action.target_player_offset if action.target_player_offset is not None else 1
+                    victim = self._get_player_at_offset(self.players.index(player), self.play_direction * t_offset)
+                    self.player_draws_card(victim, action.value)
+                if action.type == ActionType.SKIP_PLAYER: skip_after_drawn = True
+                if action.type == ActionType.REVERSE_DIRECTION: self.play_direction *= -1
+
+            if self.game_over: return True, " ".join(filter(None, message_parts))
+            self.current_player_index = self.players.index(player)
+            self._advance_turn_marker()
+            if skip_after_drawn:
+                message_parts.append(f"{self.get_current_player().name}'s turn is skipped.")
+                self._advance_turn_marker()
+            return True, " ".join(filter(None, message_parts))
+        else:
+            message_parts.append(f"The drawn card ({drawn_card}) is not playable. Turn ends.")
+            self.current_player_index = self.players.index(player)
+            self._advance_turn_marker()
+            return True, " ".join(filter(None, message_parts))
+
+    def get_game_status(self):
+        if self.game_over:
+            return f"Game Over! Winner: {self.winner.name if self.winner else 'None'}"
+        status = []
+        top_card = self.get_top_card()
+        active_color_str = f"(Active: {self.current_wild_color.name})" if self.current_wild_color and top_card and top_card.is_wild() else ""
+        status.append(f"Top Card: {top_card} {active_color_str}")
+
+        current_player_obj = self.get_current_player()
+        actor_display_name = current_player_obj.name
+        pending_action_for_whom = current_player_obj.name
+
+        if self.pending_action:
+            actor_idx = self.action_data.get('original_player_idx', # For Rank 6, etc.
+                             self.action_data.get('player_idx', # For CHOOSE_COLOR (non-Rank 6)
+                             self.action_data.get('victim_idx'))) # For DISCARD (victim is original Blue3 player)
+
+            if self.pending_action.type == ActionType.DISCARD_FROM_PLAYER_HAND:
+                actor_idx = self.action_data.get('chooser_idx') # Chooser is the actor
+
+            if actor_idx is not None:
+                pending_action_for_whom = self.players[actor_idx].name
+            elif 'player' in self.action_data: # For SWAP actions
+                pending_action_for_whom = self.action_data['player'].name
+
+
+        status.append(f"Current Player: {current_player_obj.name}")
+        if self.pending_action:
+            status.append(f"Pending Action: {self.pending_action.type.name} (requiring input from {pending_action_for_whom})")
+
+        status.append(f"Play Direction: {'Forward' if self.play_direction == 1 else 'Backward'}")
+        status.append("Players:")
+        for p in self.players:
+            details = f"{p.hand_size()} cards"
+            counters_list = []
+            if p.coins > 0: counters_list.append(f"C:{p.coins}")
+            if p.shuffle_counters > 0: counters_list.append(f"S:{p.shuffle_counters}")
+            if p.lunar_mana > 0: counters_list.append(f"L:{p.lunar_mana}")
+            if p.solar_mana > 0: counters_list.append(f"Sol:{p.solar_mana}")
+            if p.get_out_of_jail_yellow_4: counters_list.append("Y4Jail")
+            if counters_list: details += " (" + ", ".join(counters_list) + ")"
+            status.append(f"  - {p.name}: {details}")
+        status.append(f"Draw pile size: {len(self.deck.cards)}")
+        return "\n".join(status)
+
+if __name__ == '__main__':
+    game = UnoGame(["Alice", "Bob", "Charlie", "Dave"])
+    print("Initial game state:")
+    print(game.get_game_status())
+
+    max_turns = 250 # Increased for more complex games
+    for turn_num in range(max_turns):
+        if game.game_over:
+            print(f"\n--- Game Over on Turn {turn_num + 1} ---")
+            break
+
+        # Determine who is providing input for this step of the turn
+        actor_player = game.get_current_player() # Default actor is whose turn it is
+        if game.pending_action:
+            if game.pending_action.type == ActionType.DISCARD_FROM_PLAYER_HAND:
+                 actor_player = game.players[game.action_data.get('chooser_idx')]
+            elif game.pending_action.type == ActionType.CHOOSE_COLOR and game.action_data.get('is_for_rank_6_wild'):
+                 actor_player = game.players[game.action_data.get('original_player_idx')]
+            elif 'player' in game.action_data: # SWAP_CARD_RIGHT, SWAP_CARD_ANY store player object
+                 actor_player = game.action_data.get('player')
+            elif 'player_idx' in game.action_data: # CHOOSE_COLOR (normal), PLAY_ANY_AND_DRAW_ONE
+                 actor_player = game.players[game.action_data.get('player_idx')]
+            # If original_player_idx is present, it's the one who initiated the multi-step action
+            elif 'original_player_idx' in game.action_data:
+                 actor_player = game.players[game.action_data.get('original_player_idx')]
+
+
+        print(f"\n--- Turn {turn_num + 1}: Main turn for {game.get_current_player().name}, Input from {actor_player.name} ---")
+        print(f"{actor_player.name}'s Hand: {actor_player.get_hand_display()}")
+
+        turn_message = ""
+        action_input_sim = {}
+        card_idx_sim = None
+
+        if game.pending_action:
+            print(f"Sim: Handling pending action {game.pending_action.type.name} for {actor_player.name}.")
+
+            if game.pending_action.type == ActionType.SWAP_CARD_RIGHT :
+                if not actor_player.is_hand_empty(): action_input_sim['card_to_give_idx'] = random.randint(0, actor_player.hand_size()-1)
+                else: action_input_sim['card_to_give_idx'] = 0
+                player_to_right_idx = (game.players.index(actor_player) + game.play_direction) % len(game.players)
+                player_to_right = game.players[player_to_right_idx]
+                if not player_to_right.is_hand_empty(): action_input_sim['card_to_take_idx'] = random.randint(0, player_to_right.hand_size()-1)
+                else: action_input_sim['card_to_take_idx'] = 0
+
+            elif game.pending_action.type == ActionType.SWAP_CARD_ANY:
+                if 'target_player_idx' not in game.action_data:
+                    possible_targets = [i for i, p in enumerate(game.players) if i != game.players.index(actor_player)]
+                    action_input_sim['target_player_idx'] = random.choice(possible_targets) if possible_targets else (game.players.index(actor_player) + 1) % len(game.players)
+                else:
+                    target_player = game.players[game.action_data['target_player_idx']]
+                    if not actor_player.is_hand_empty(): action_input_sim['card_to_give_idx'] = random.randint(0, actor_player.hand_size()-1)
+                    else: action_input_sim['card_to_give_idx'] = 0
+                    if not target_player.is_hand_empty(): action_input_sim['card_to_take_idx'] = random.randint(0, target_player.hand_size()-1)
+                    else: action_input_sim['card_to_take_idx'] = 0
+
+            elif game.pending_action.type == ActionType.DISCARD_FROM_PLAYER_HAND:
+                victim = game.players[game.action_data['victim_idx']]
+                num_to_pick = min(victim.hand_size(), game.action_data.get('count',2))
+                if victim.hand_size() > 0: action_input_sim['chosen_indices_from_victim'] = random.sample(range(victim.hand_size()), num_to_pick)
+                else: action_input_sim['chosen_indices_from_victim'] = []
+
+            elif game.pending_action.type == ActionType.PLAY_ANY_AND_DRAW_ONE:
+                if not actor_player.is_hand_empty():
+                    card_idx_sim = random.randint(0, actor_player.hand_size() -1)
+                    chosen_card_for_rank6 = actor_player.hand[card_idx_sim]
+                    if chosen_card_for_rank6.is_wild():
+                        action_input_sim['chosen_color_for_rank_6_wild'] = random.choice([c for c in Color if c != Color.WILD])
+                else: card_idx_sim = 0 # Will fail if hand empty, game logic should handle
+
+            elif game.pending_action.type == ActionType.CHOOSE_COLOR:
+                action_input_sim['chosen_color'] = random.choice([c for c in Color if c != Color.WILD])
+
+            print(f"Sim input for {game.pending_action.type.name}: card_idx={card_idx_sim}, action_input={action_input_sim}")
+            success, message_pending, next_action_prompt = game.play_turn(actor_player, card_idx_sim, action_input_sim)
+            turn_message = message_pending
+            if not success: print(f"Error completing pending action: {message_pending}")
+            if next_action_prompt: print(f"SIM: Pending action for {actor_player.name} resulted in new prompt: {next_action_prompt}")
+
+        else: # No pending action, normal play by current_turn_player_obj
+            playable_cards_indices = [i for i, card in enumerate(actor_player.hand)
+                                      if card.matches(game.get_top_card(), game.current_wild_color)]
+
+            if playable_cards_indices:
+                card_idx_sim = random.choice(playable_cards_indices)
+                card_being_played = actor_player.hand[card_idx_sim]
+                chosen_color_sim_val = None
+                if card_being_played.is_wild():
+                    chosen_color_sim_val = random.choice([c for c in Color if c != Color.WILD])
+
+                success, message_play, next_action_prompt = game.play_turn(actor_player, card_idx_sim, chosen_color_for_wild=chosen_color_sim_val)
+                turn_message = message_play
+                if not success: print(f"Play failed: {message_play}")
+                if next_action_prompt: print(f"SIM: Normal play by {actor_player.name} resulted in prompt: {next_action_prompt}")
+            else:
+                if actor_player.has_get_out_of_jail_card():
+                    y4 = actor_player.get_out_of_jail_yellow_4
+                    if y4 and y4.matches(game.get_top_card(), game.current_wild_color):
+                        actor_player.use_get_out_of_jail_card()
+                        game.deck.add_to_discard(y4)
+                        game.current_wild_color = None
+                        game._award_color_counters(actor_player, y4)
+                        turn_message = f"{actor_player.name} uses 'Get Out of Jail Free' Yellow 4."
+                        if actor_player.is_hand_empty(): game.game_over=True; game.winner=actor_player; turn_message+= " And WINS!"
+                        else: game.current_player_index = game.players.index(actor_player); game._advance_turn_marker()
+                    else:
+                        if y4: actor_player.store_yellow_4_get_out_of_jail(y4)
+                        success, message_draw = game.player_cannot_play_action(actor_player)
+                        turn_message = message_draw
+                else:
+                    success, message_draw = game.player_cannot_play_action(actor_player)
+                    turn_message = message_draw
+
+        print(turn_message.strip())
+        print(game.get_game_status())
+
+    print("\n--- Final Game Status ---")
+    print(game.get_game_status())
+    if not game.game_over: print(f"\nGame ended due to max turns ({max_turns}).")
+    elif game.winner: print(f"\nWinner: {game.winner.name}")
+    else: print("\nGame over, but winner not set.")
+
+    print("\nFinal Player Hands & Counters:")
+    for p_final in game.players:
+        counters_list_final = []
+        if p_final.coins > 0: counters_list_final.append(f"C:{p_final.coins}")
+        if p_final.shuffle_counters > 0: counters_list_final.append(f"S:{p_final.shuffle_counters}")
+        if p_final.lunar_mana > 0: counters_list_final.append(f"L:{p_final.lunar_mana}")
+        if p_final.solar_mana > 0: counters_list_final.append(f"Sol:{p_final.solar_mana}")
+        if p_final.get_out_of_jail_yellow_4: counters_list_final.append("Y4Jail")
+        counter_str_final = ", ".join(counters_list_final)
+        hand_str_final = p_final.get_hand_display(show_indices=False) if p_final.hand_size() > 0 else "Empty"
+        print(f"{p_final.name}: {hand_str_final} --- Counters: [{counter_str_final if counter_str_final else 'None'}]")

--- a/uno_game/src/player.py
+++ b/uno_game/src/player.py
@@ -1,0 +1,205 @@
+from typing import List, Optional
+from .card import Card, Color, Rank # Assuming card.py is in the same directory
+
+class Player:
+    def __init__(self, name: str):
+        self.name: str = name
+        self.hand: List[Card] = []
+
+        # Game-specific counters
+        self.coins: int = 0
+        self.shuffle_counters: int = 0
+        self.lunar_mana: int = 0
+        self.solar_mana: int = 0
+
+        # Special Yellow 4 rule
+        self.get_out_of_jail_yellow_4: Optional[Card] = None
+
+    def add_card_to_hand(self, card: Card):
+        """Adds a single card to the player's hand."""
+        if not isinstance(card, Card):
+            raise TypeError("Can only add Card objects to hand.")
+        self.hand.append(card)
+
+    def add_cards_to_hand(self, cards: List[Card]):
+        """Adds multiple cards to the player's hand."""
+        for card in cards:
+            self.add_card_to_hand(card) # Leverage the single card add for type checking
+
+    def remove_card_from_hand(self, card_to_remove: Card) -> Optional[Card]:
+        """
+        Removes a specific card from the player's hand.
+        Returns the card if found and removed, otherwise None.
+        Need to be careful if player has multiple identical cards.
+        This implementation removes the first encountered match.
+        """
+        try:
+            self.hand.remove(card_to_remove) # Relies on Card.__eq__
+            return card_to_remove
+        except ValueError:
+            # Card not found in hand
+            return None
+
+    def play_card(self, card_index: int) -> Optional[Card]:
+        """
+        Plays a card from the player's hand by its index.
+        Returns the card if the index is valid, otherwise None.
+        """
+        if 0 <= card_index < len(self.hand):
+            return self.hand.pop(card_index)
+        return None
+
+    def has_card(self, card_to_check: Card) -> bool:
+        """Checks if the player has a specific card in hand."""
+        return card_to_check in self.hand
+
+    def hand_size(self) -> int:
+        """Returns the number of cards in the player's hand."""
+        return len(self.hand)
+
+    def is_hand_empty(self) -> bool:
+        """Checks if the player's hand is empty."""
+        return not self.hand
+
+    def can_play_on(self, top_discard_card: Card, current_wild_color: Optional[Color]) -> List[Card]:
+        """
+        Returns a list of playable cards from the hand given the top discard card
+        and the active color if the top card is a Wild.
+        """
+        playable_cards = []
+        for card in self.hand:
+            if card.matches(top_discard_card, current_wild_color):
+                playable_cards.append(card)
+        return playable_cards
+
+    def has_playable_card(self, top_discard_card: Card, current_wild_color: Optional[Color]) -> bool:
+        """Checks if the player has any card they can play."""
+        return any(card.matches(top_discard_card, current_wild_color) for card in self.hand)
+
+    def store_yellow_4_get_out_of_jail(self, card: Card):
+        """Stores a Yellow 4 card for 'get out of jail free' pile."""
+        if card.color == Color.YELLOW and card.rank == Rank.FOUR:
+            if self.get_out_of_jail_yellow_4 is None: # Rule: cannot be accumulated
+                self.get_out_of_jail_yellow_4 = card
+                return True
+        return False
+
+    def use_get_out_of_jail_card(self) -> Optional[Card]:
+        """Uses the stored Yellow 4 card."""
+        card = self.get_out_of_jail_yellow_4
+        self.get_out_of_jail_yellow_4 = None
+        return card
+
+    def has_get_out_of_jail_card(self) -> bool:
+        return self.get_out_of_jail_yellow_4 is not None
+
+    def get_hand_display(self, show_indices: bool = True) -> str:
+        """Returns a string representation of the player's hand."""
+        if not self.hand:
+            return "Hand is empty."
+        display = []
+        for i, card in enumerate(self.hand):
+            if show_indices:
+                display.append(f"{i}: {str(card)}")
+            else:
+                display.append(str(card))
+        return ", ".join(display)
+
+    def __str__(self):
+        return f"Player {self.name} (Cards: {self.hand_size()}, Coins: {self.coins}, Shuffles: {self.shuffle_counters}, Lunar: {self.lunar_mana}, Solar: {self.solar_mana})"
+
+    def __repr__(self):
+        return f"Player(name='{self.name}')"
+
+if __name__ == '__main__':
+    player1 = Player("Alice")
+    print(player1)
+
+    # Test adding cards
+    red_1 = Card(Color.RED, Rank.ONE)
+    blue_2 = Card(Color.BLUE, Rank.TWO)
+    red_1_dup = Card(Color.RED, Rank.ONE) # Duplicate for testing removal
+
+    player1.add_card_to_hand(red_1)
+    player1.add_cards_to_hand([blue_2, red_1_dup])
+    print(f"{player1.name}'s hand: {player1.get_hand_display()}")
+    assert player1.hand_size() == 3
+
+    # Test removing card
+    removed = player1.remove_card_from_hand(red_1)
+    print(f"Removed: {removed}")
+    assert removed == red_1
+    assert player1.hand_size() == 2
+    print(f"{player1.name}'s hand after removing RED ONE: {player1.get_hand_display()}")
+
+    # Test removing card not in hand
+    green_5 = Card(Color.GREEN, Rank.FIVE)
+    removed_none = player1.remove_card_from_hand(green_5)
+    assert removed_none is None
+    assert player1.hand_size() == 2
+
+    # Test playing card by index
+    # Hand should be [BLUE TWO, RED ONE]
+    played_card = player1.play_card(0) # Play BLUE TWO
+    assert played_card == blue_2
+    assert player1.hand_size() == 1
+    print(f"{player1.name}'s hand after playing by index: {player1.get_hand_display()}")
+
+    played_invalid = player1.play_card(5) # Invalid index
+    assert played_invalid is None
+    assert player1.hand_size() == 1
+
+    # Test can_play_on / has_playable_card
+    # Hand: [RED ONE]
+    player1.add_card_to_hand(Card(Color.BLUE, Rank.SEVEN)) # Hand: [RED ONE, BLUE SEVEN]
+    print(f"{player1.name}'s hand: {player1.get_hand_display()}")
+
+    top_discard_red_5 = Card(Color.RED, Rank.FIVE)
+    playable = player1.can_play_on(top_discard_red_5, None)
+    print(f"Playable on RED FIVE: {[str(c) for c in playable]}") # Should be RED ONE
+    assert any(c.color == Color.RED and c.rank == Rank.ONE for c in playable)
+    assert player1.has_playable_card(top_discard_red_5, None)
+
+    top_discard_yellow_7 = Card(Color.YELLOW, Rank.SEVEN)
+    playable = player1.can_play_on(top_discard_yellow_7, None)
+    print(f"Playable on YELLOW SEVEN: {[str(c) for c in playable]}") # Should be BLUE SEVEN
+    assert any(c.color == Color.BLUE and c.rank == Rank.SEVEN for c in playable)
+    assert player1.has_playable_card(top_discard_yellow_7, None)
+
+    top_discard_green_skip = Card(Color.GREEN, Rank.SKIP)
+    playable = player1.can_play_on(top_discard_green_skip, None) # Should be none
+    print(f"Playable on GREEN SKIP: {[str(c) for c in playable]}")
+    assert not player1.has_playable_card(top_discard_green_skip, None)
+
+    # Test with Wild card on table
+    wild_on_table = Card(Color.WILD, Rank.WILD)
+    # wild_on_table.active_color = Color.BLUE # Player chose blue
+    playable_on_wild_blue = player1.can_play_on(wild_on_table, Color.BLUE)
+    print(f"Playable on WILD (active BLUE): {[str(c) for c in playable_on_wild_blue]}") # BLUE SEVEN
+    assert any(c.color == Color.BLUE and c.rank == Rank.SEVEN for c in playable_on_wild_blue)
+
+    # Test Yellow 4 "get out of jail"
+    yellow_4_card = Card(Color.YELLOW, Rank.FOUR)
+    not_yellow_4 = Card(Color.RED, Rank.FOUR)
+
+    assert not player1.has_get_out_of_jail_card()
+    stored_y4 = player1.store_yellow_4_get_out_of_jail(yellow_4_card)
+    assert stored_y4
+    assert player1.has_get_out_of_jail_card()
+    assert player1.get_out_of_jail_yellow_4 == yellow_4_card
+
+    # Try storing another one (should not accumulate)
+    another_y4 = Card(Color.YELLOW, Rank.FOUR)
+    stored_another_y4 = player1.store_yellow_4_get_out_of_jail(another_y4)
+    assert not stored_another_y4 # Cannot store if one already exists
+    assert player1.get_out_of_jail_yellow_4 == yellow_4_card # Original one still there
+
+    stored_not_y4 = player1.store_yellow_4_get_out_of_jail(not_yellow_4)
+    assert not stored_not_y4
+
+    used_y4 = player1.use_get_out_of_jail_card()
+    assert used_y4 == yellow_4_card
+    assert not player1.has_get_out_of_jail_card()
+    assert player1.get_out_of_jail_yellow_4 is None
+
+    print("Player class tests completed.")

--- a/uno_game/src/shop.py
+++ b/uno_game/src/shop.py
@@ -1,0 +1,116 @@
+# Placeholder for the Shop system
+
+from typing import TYPE_CHECKING, Dict, Any, Optional
+
+if TYPE_CHECKING:
+    from .player import Player # To avoid circular import if Player needs Shop or vice-versa
+
+class ShopItem:
+    def __init__(self, name: str, cost: int, description: str, effect_id: str):
+        self.name = name
+        self.cost = cost
+        self.description = description
+        self.effect_id = effect_id # An identifier to apply the effect
+
+    def __str__(self):
+        return f"{self.name} (Cost: {self.cost} coins) - {self.description}"
+
+class Shop:
+    def __init__(self):
+        self.items: Dict[str, ShopItem] = {}
+        self._initialize_items()
+
+    def _initialize_items(self):
+        # Placeholder items - these would be defined with actual game effects
+        self.items["draw_one_less"] = ShopItem(
+            name="Lucky Charm",
+            cost=5,
+            description="Next time you're forced to draw multiple cards (e.g., Draw 2, Draw 4), draw one less.",
+            effect_id="draw_one_less"
+        )
+        self.items["extra_shuffle_token"] = ShopItem(
+            name="Shuffle Token",
+            cost=3,
+            description="Gain an extra shuffle token.",
+            effect_id="gain_shuffle_token"
+        )
+        self.items["peek_opponent_hand"] = ShopItem(
+            name="Spyglass",
+            cost=7,
+            description="Briefly peek at one opponent's hand (e.g., 3 cards randomly).",
+            effect_id="peek_hand"
+        )
+        # More items can be added here
+
+    def display_items(self) -> str:
+        if not self.items:
+            return "The shop is currently empty."
+        display = ["Welcome to the Shop! Available items:"]
+        for item_id, item in self.items.items():
+            display.append(f"  [{item_id}] {item}")
+        return "\n".join(display)
+
+    def purchase_item(self, player: 'Player', item_id: str) -> Tuple[bool, str]:
+        """
+        Allows a player to purchase an item.
+        Returns (success, message).
+        Actual application of item effect is handled by game logic based on player's inventory/status.
+        """
+        item_to_buy = self.items.get(item_id)
+        if not item_to_buy:
+            return False, "Invalid item ID."
+
+        if player.coins < item_to_buy.cost:
+            return False, f"Not enough coins. You have {player.coins}, need {item_to_buy.cost}."
+
+        player.coins -= item_to_buy.cost
+
+        # Placeholder for adding item to player's inventory or applying immediate effect
+        # This would depend on how item effects are managed (e.g., player status flags, inventory list)
+        message = f"{player.name} purchased {item_to_buy.name} for {item_to_buy.cost} coins."
+
+        if item_to_buy.effect_id == "gain_shuffle_token":
+            player.shuffle_counters += 1
+            message += f" Gained 1 shuffle token (Total: {player.shuffle_counters})."
+        else:
+            # For other items, the game would need to track that the player owns this item/effect.
+            # e.g., player.active_shop_effects.append(item_to_buy.effect_id)
+            # Or player.inventory.append(item_to_buy)
+            message += f" (Effect '{item_to_buy.effect_id}' needs to be applied by game logic)."
+            print(f"Debug: Player {player.name} now has effect '{item_to_buy.effect_id}' pending.")
+
+
+        return True, message
+
+if __name__ == '__main__':
+    # Basic test
+    shop = Shop()
+    print(shop.display_items())
+
+    # Dummy player for testing
+    class DummyPlayer:
+        def __init__(self, name, coins=10):
+            self.name = name
+            self.coins = coins
+            self.shuffle_counters = 0
+            # In a real game, player would have an inventory or status effects list
+            # self.inventory = []
+            # self.active_effects = []
+
+    player_alice = DummyPlayer("Alice", 10)
+
+    success, msg = shop.purchase_item(player_alice, "extra_shuffle_token")
+    print(msg) # Alice purchased Shuffle Token... Gained 1 shuffle token...
+    print(f"Alice's coins: {player_alice.coins}, Shuffles: {player_alice.shuffle_counters}")
+
+    success, msg = shop.purchase_item(player_alice, "draw_one_less")
+    print(msg) # Alice purchased Lucky Charm... (Effect needs to be applied...)
+    print(f"Alice's coins: {player_alice.coins}")
+
+    success, msg = shop.purchase_item(player_alice, "non_existent_item")
+    print(msg) # Invalid item ID
+
+    player_bob = DummyPlayer("Bob", 2)
+    success, msg = shop.purchase_item(player_bob, "extra_shuffle_token")
+    print(msg) # Not enough coins...
+    print(f"Bob's coins: {player_bob.coins}")

--- a/uno_game/src/spells.py
+++ b/uno_game/src/spells.py
@@ -1,0 +1,201 @@
+# Placeholder for Lunar and Solar Spells
+
+from typing import TYPE_CHECKING, Tuple, Dict, Any
+
+if TYPE_CHECKING:
+    from .player import Player
+    from .game import UnoGame # For spells that might affect game state or other players
+
+class Spell:
+    def __init__(self, name: str, mana_cost: int, description: str, spell_id: str, targetable: bool = False):
+        self.name = name
+        self.mana_cost = mana_cost
+        self.description = description
+        self.spell_id = spell_id
+        self.targetable = targetable # Does the spell require a target player?
+
+    def __str__(self):
+        return f"{self.name} (Cost: {self.mana_cost} mana) - {self.description}"
+
+class LunarSpells:
+    def __init__(self):
+        self.spells: Dict[str, Spell] = {}
+        self._initialize_spells()
+
+    def _initialize_spells(self):
+        # Placeholder Lunar Spells
+        self.spells["moonbeam_draw"] = Spell(
+            name="Moonbeam Draw",
+            mana_cost=3,
+            description="Force a target player to draw 1 card.",
+            spell_id="moonbeam_draw",
+            targetable=True
+        )
+        self.spells["lunar_shield"] = Spell(
+            name="Lunar Shield",
+            mana_cost=5,
+            description="Protect yourself from the next 'draw' effect (e.g., Draw 2, Draw 4) played against you.",
+            spell_id="lunar_shield"
+        )
+        self.spells["shadow_swap_peek"] = Spell(
+            name="Shadow Swap Peek",
+            mana_cost=4,
+            description="Peek at one card from a target player's hand, then you may swap it with one of yours.",
+            spell_id="shadow_swap_peek",
+            targetable=True
+        )
+        # More spells
+
+    def display_spells(self) -> str:
+        if not self.spells:
+            return "No Lunar spells known."
+        display = ["Available Lunar Spells:"]
+        for spell_id, spell in self.spells.items():
+            display.append(f"  [{spell_id}] {spell}")
+        return "\n".join(display)
+
+    def cast_spell(self, caster: 'Player', spell_id: str, game_context: 'UnoGame', target_player: Optional['Player'] = None) -> Tuple[bool, str]:
+        """
+        Casts a lunar spell.
+        Returns (success, message).
+        Actual application of spell effect is handled by game logic.
+        """
+        spell_to_cast = self.spells.get(spell_id)
+        if not spell_to_cast:
+            return False, "Unknown Lunar spell."
+
+        if caster.lunar_mana < spell_to_cast.mana_cost:
+            return False, f"Not enough Lunar Mana. You have {caster.lunar_mana}, need {spell_to_cast.mana_cost}."
+
+        if spell_to_cast.targetable and target_player is None:
+            return False, f"Spell '{spell_to_cast.name}' requires a target player."
+
+        if spell_to_cast.targetable and target_player == caster:
+            # Some targetable spells might allow self-targeting, others not. Add specific checks if needed.
+             pass
+
+
+        caster.lunar_mana -= spell_to_cast.mana_cost
+
+        message = f"{caster.name} casts {spell_to_cast.name} (cost {spell_to_cast.mana_cost} Lunar Mana)."
+
+        # Placeholder for spell effects - these would modify game_context or players
+        if spell_to_cast.spell_id == "moonbeam_draw" and target_player:
+            message += f" Targeting {target_player.name}."
+            # game_context.player_draws_card(target_player, 1) # Example of direct effect
+            # In reality, this might return an action for the game loop to process.
+            message += f" ({target_player.name} should draw 1 card - effect needs full game logic integration)."
+            print(f"Debug: {target_player.name} targeted by Moonbeam Draw.")
+
+        elif spell_to_cast.spell_id == "lunar_shield":
+            # caster.add_status_effect("lunar_shield_active") # Example
+            message += f" {caster.name} is now shielded from the next draw effect (effect needs game logic)."
+            print(f"Debug: {caster.name} gained Lunar Shield.")
+
+        else:
+            message += f" (Effect '{spell_to_cast.spell_id}' needs to be applied by game logic)."
+            print(f"Debug: Spell '{spell_to_cast.spell_id}' cast by {caster.name}.")
+
+
+        return True, message
+
+class SolarSpells:
+    def __init__(self):
+        self.spells: Dict[str, Spell] = {}
+        self._initialize_spells()
+
+    def _initialize_spells(self):
+        # Placeholder Solar Spells
+        self.spells["sun_flare_discard"] = Spell(
+            name="Sun Flare Discard",
+            mana_cost=3,
+            description="Force a target player to discard a random card.",
+            spell_id="sun_flare_discard",
+            targetable=True
+        )
+        self.spells["solar_boost"] = Spell(
+            name="Solar Boost",
+            mana_cost=4,
+            description="Your next played number card counts as +2 to its value for stacking (if applicable) or a game objective.",
+            spell_id="solar_boost"
+        )
+        # More spells
+
+    def display_spells(self) -> str:
+        if not self.spells:
+            return "No Solar spells known."
+        display = ["Available Solar Spells:"]
+        for spell_id, spell in self.spells.items():
+            display.append(f"  [{spell_id}] {spell}")
+        return "\n".join(display)
+
+    def cast_spell(self, caster: 'Player', spell_id: str, game_context: 'UnoGame', target_player: Optional['Player'] = None) -> Tuple[bool, str]:
+        """
+        Casts a solar spell.
+        Returns (success, message).
+        """
+        spell_to_cast = self.spells.get(spell_id)
+        if not spell_to_cast:
+            return False, "Unknown Solar spell."
+
+        if caster.solar_mana < spell_to_cast.mana_cost:
+            return False, f"Not enough Solar Mana. You have {caster.solar_mana}, need {spell_to_cast.mana_cost}."
+
+        if spell_to_cast.targetable and target_player is None:
+            return False, f"Spell '{spell_to_cast.name}' requires a target player."
+
+        caster.solar_mana -= spell_to_cast.mana_cost
+        message = f"{caster.name} casts {spell_to_cast.name} (cost {spell_to_cast.mana_cost} Solar Mana)."
+
+        # Placeholder for spell effects
+        if spell_to_cast.spell_id == "sun_flare_discard" and target_player:
+            message += f" Targeting {target_player.name}."
+            # if not target_player.is_hand_empty():
+            #     discarded = target_player.remove_card_from_hand(random.choice(target_player.hand)) # Needs better removal
+            #     game_context.deck.add_to_discard(discarded)
+            #     message += f" {target_player.name} discards {discarded}."
+            # else: message += f" {target_player.name} has no cards to discard."
+            message += f" ({target_player.name} should discard a random card - effect needs full game logic integration)."
+            print(f"Debug: {target_player.name} targeted by Sun Flare Discard.")
+        else:
+            message += f" (Effect '{spell_to_cast.spell_id}' needs to be applied by game logic)."
+            print(f"Debug: Spell '{spell_to_cast.spell_id}' cast by {caster.name}.")
+
+        return True, message
+
+if __name__ == '__main__':
+    lunar_magic = LunarSpells()
+    solar_magic = SolarSpells()
+
+    print(lunar_magic.display_spells())
+    print("\n" + solar_magic.display_spells())
+
+    # Dummy player and game for testing
+    class DummyPlayer:
+        def __init__(self, name, lunar=5, solar=5):
+            self.name = name
+            self.lunar_mana = lunar
+            self.solar_mana = solar
+
+    class DummyGame: # Placeholder for UnoGame context
+        pass
+
+    player_merlin = DummyPlayer("Merlin", lunar=10, solar=10)
+    player_morgana = DummyPlayer("Morgana")
+    dummy_game = DummyGame()
+
+    print("\n--- Merlin's Casts ---")
+    success, msg = lunar_magic.cast_spell(player_merlin, "moonbeam_draw", dummy_game, target_player=player_morgana)
+    print(msg)
+    print(f"Merlin's Lunar Mana: {player_merlin.lunar_mana}")
+
+    success, msg = solar_magic.cast_spell(player_merlin, "sun_flare_discard", dummy_game, target_player=player_morgana)
+    print(msg)
+    print(f"Merlin's Solar Mana: {player_merlin.solar_mana}")
+
+    success, msg = lunar_magic.cast_spell(player_merlin, "bad_spell_id", dummy_game)
+    print(msg) # Unknown
+
+    player_arthur = DummyPlayer("Arthur", lunar=1, solar=1)
+    success, msg = lunar_magic.cast_spell(player_arthur, "lunar_shield", dummy_game)
+    print(msg) # Not enough mana

--- a/uno_game/tests/__init__.py
+++ b/uno_game/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes 'tests' a Python package.

--- a/uno_game/tests/test_card.py
+++ b/uno_game/tests/test_card.py
@@ -1,0 +1,129 @@
+import unittest
+from src.card import Card, Color, Rank # Corrected import path relative to project root
+
+class TestCard(unittest.TestCase):
+
+    def test_card_creation(self):
+        card = Card(Color.RED, Rank.FIVE)
+        self.assertEqual(card.color, Color.RED)
+        self.assertEqual(card.rank, Rank.FIVE)
+        self.assertEqual(card.active_color, Color.RED) # Should be same as color initially
+
+    def test_wild_card_creation(self):
+        wild_card = Card(Color.WILD, Rank.WILD)
+        self.assertEqual(wild_card.color, Color.WILD)
+        self.assertEqual(wild_card.rank, Rank.WILD)
+        self.assertEqual(wild_card.active_color, Color.WILD) # Active color starts as WILD
+
+        wd4 = Card(Color.WILD, Rank.WILD_DRAW_FOUR)
+        self.assertEqual(wd4.color, Color.WILD)
+        self.assertEqual(wd4.rank, Rank.WILD_DRAW_FOUR)
+
+    def test_wild_card_auto_color_correction(self):
+        # If a color like RED is passed with Rank.WILD, it should be corrected to Color.WILD
+        card = Card(Color.RED, Rank.WILD)
+        self.assertEqual(card.color, Color.WILD)
+        self.assertEqual(card.rank, Rank.WILD)
+
+    def test_invalid_card_creation(self):
+        with self.assertRaises(TypeError):
+            Card("RED", Rank.FIVE)  # Invalid color type
+        with self.assertRaises(TypeError):
+            Card(Color.RED, "FIVE") # Invalid rank type
+        with self.assertRaises(ValueError):
+            # Non-wild ranks cannot have WILD color
+            Card(Color.WILD, Rank.ONE)
+
+    def test_card_string_representation(self):
+        red_five = Card(Color.RED, Rank.FIVE)
+        self.assertEqual(str(red_five), "RED FIVE")
+
+        blue_skip = Card(Color.BLUE, Rank.SKIP)
+        self.assertEqual(str(blue_skip), "BLUE SKIP")
+
+        wild = Card(Color.WILD, Rank.WILD)
+        self.assertEqual(str(wild), "WILD") # Before color is chosen
+        wild.active_color = Color.GREEN
+        self.assertEqual(str(wild), "WILD (GREEN)") # After color is chosen
+
+        wd4 = Card(Color.WILD, Rank.WILD_DRAW_FOUR)
+        self.assertEqual(str(wd4), "WILD_DRAW_FOUR")
+        wd4.active_color = Color.BLUE
+        self.assertEqual(str(wd4), "WILD (BLUE)") # Note: WD4 str might also show (BLUE)
+
+    def test_card_equality(self):
+        card1 = Card(Color.RED, Rank.ONE)
+        card2 = Card(Color.RED, Rank.ONE)
+        card3 = Card(Color.BLUE, Rank.ONE)
+        card4 = Card(Color.RED, Rank.TWO)
+
+        self.assertEqual(card1, card2)
+        self.assertNotEqual(card1, card3)
+        self.assertNotEqual(card1, card4)
+        self.assertNotEqual(card1, "RED ONE") # Test against different type
+
+    def test_card_hash(self):
+        # Test that equal cards have the same hash (for set/dict usage)
+        card1 = Card(Color.RED, Rank.ONE)
+        card2 = Card(Color.RED, Rank.ONE)
+        self.assertEqual(hash(card1), hash(card2))
+
+        card_set = {card1, card2}
+        self.assertEqual(len(card_set), 1)
+
+        card3 = Card(Color.BLUE, Rank.ONE)
+        card_set.add(card3)
+        self.assertEqual(len(card_set), 2)
+
+    def test_is_special_action(self):
+        self.assertTrue(Card(Color.RED, Rank.DRAW_TWO).is_special_action())
+        self.assertTrue(Card(Color.BLUE, Rank.SKIP).is_special_action())
+        self.assertTrue(Card(Color.GREEN, Rank.REVERSE).is_special_action())
+        self.assertFalse(Card(Color.YELLOW, Rank.FIVE).is_special_action())
+        self.assertFalse(Card(Color.WILD, Rank.WILD).is_special_action()) # Wilds are not "special action" in this context
+
+    def test_is_wild(self):
+        self.assertTrue(Card(Color.WILD, Rank.WILD).is_wild())
+        self.assertTrue(Card(Color.WILD, Rank.WILD_DRAW_FOUR).is_wild())
+        self.assertFalse(Card(Color.RED, Rank.DRAW_TWO).is_wild())
+        self.assertFalse(Card(Color.BLUE, Rank.FIVE).is_wild())
+
+    def test_card_matches(self):
+        red_five = Card(Color.RED, Rank.FIVE)
+        red_seven = Card(Color.RED, Rank.SEVEN)
+        blue_five = Card(Color.BLUE, Rank.FIVE)
+        green_two = Card(Color.GREEN, Rank.TWO)
+
+        # Color match
+        self.assertTrue(red_seven.matches(red_five))
+        # Rank match
+        self.assertTrue(blue_five.matches(red_five))
+        # No match
+        self.assertFalse(green_two.matches(red_five))
+
+        # Wild card matching
+        wild_card = Card(Color.WILD, Rank.WILD)
+        # Wild card can be played on anything
+        self.assertTrue(wild_card.matches(red_five))
+        self.assertTrue(wild_card.matches(green_two))
+
+        # Playing on a wild card
+        # If wild_on_table has active_color BLUE
+        wild_on_table = Card(Color.WILD, Rank.WILD) # Its own color is WILD
+        # wild_on_table.active_color = Color.BLUE # This would be set by game state (current_wild_color)
+
+        blue_card = Card(Color.BLUE, Rank.ONE)
+        red_card = Card(Color.RED, Rank.ONE)
+
+        self.assertTrue(blue_card.matches(wild_on_table, current_color_chosen_for_wild=Color.BLUE))
+        self.assertFalse(red_card.matches(wild_on_table, current_color_chosen_for_wild=Color.BLUE))
+        # If no color chosen for wild on table (e.g. start of game), should not match non-wilds
+        self.assertFalse(blue_card.matches(wild_on_table, current_color_chosen_for_wild=None))
+        # An unchosen wild should still match its own color (WILD), which another Wild card would do
+        another_wild = Card(Color.WILD, Rank.WILD_DRAW_FOUR)
+        self.assertTrue(another_wild.matches(wild_on_table, current_color_chosen_for_wild=None)) # Wild on Wild
+        self.assertTrue(another_wild.matches(wild_on_table, current_color_chosen_for_wild=Color.RED)) # Wild on chosen Wild
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implemented the core game logic for a custom Uno game, including:
- Card, Deck, Player, and Game classes.
- An action-based system for handling card effects.
- All specified custom card rules:
  - Rank 7: Swap card right
  - Rank 0: Swap card any player
  - Blue 3: Left player discards 2 from your hand
  - Red 8: Player draws 4 unless last card
  - Rank 6: Play any 1 card, draw 1
  - Green 5: Take random card from previous player
  - Yellow 4: Get out of jail free pile mechanic
  - Rank 9: Place top card from draw pile, new card takes effect
  - Rank 2: Discard all 2s on duplicate play
- Awarding of color-based counters (coins, mana, shuffle tokens).
- Shuffle counter mechanic for empty draw pile.
- Stubs for Shop and Spell systems.

Began unit testing with `test_card.py`. Encountered persistent module resolution issues when trying to run tests using `unittest`. Attempted various configurations including PYTHONPATH adjustments and `unittest discover` after ensuring all directories (`uno_game`, `uno_game/src`, `uno_game/tests`) were packages with `__init__.py` files. The test execution environment setup remains the primary unresolved issue.