### PR TITLE
feat: Setup Flask server and initial game_state API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,34 @@ make run
 ```
 This will execute `uno_game/src/game.py`, which might contain a basic game simulation loop.
 
-(A proper CLI entry point is planned for the future).
+### Running the Web Server (for API access)
+
+A simple Flask web server is available to expose game logic via an API. This is intended for development and integration with a potential frontend.
+
+1.  **Ensure dependencies are installed:**
+    If you haven't already, set up the project and install dependencies:
+    ```bash
+    make setup
+    ```
+
+2.  **Activate the virtual environment:**
+    ```bash
+    source .venv/bin/activate
+    ```
+
+3.  **Run the server:**
+    ```bash
+    ./run.sh
+    ```
+    This will start the Flask development server, typically on `http://0.0.0.0:5000/`.
+
+    The main API endpoint available is:
+    *   `GET /api/game_state`: Returns the current state of the Uno game. You can access this in your browser or with a tool like `curl`:
+        ```bash
+        curl http://localhost:5000/api/game_state
+        ```
+
+(A proper CLI entry point for the game itself is planned for the future).
 
 ## Development
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,28 @@
+from flask import Flask, jsonify
+from uno_game.src.game import UnoGame
+from uno_game.src.player import Player
+
+app = Flask(__name__)
+
+# Initialize a global game instance for simplicity
+# In a real application, you'd manage game instances differently (e.g., sessions, database)
+try:
+    game = UnoGame(player_names=["Player 1", "CPU 1", "CPU 2"])
+except ValueError as e:
+    print(f"Error initializing game: {e}")
+    # Fallback or exit, depending on desired behavior
+    game = None
+
+@app.route('/api/game_state', methods=['GET'])
+def get_game_state():
+    if game:
+        return jsonify(game.to_dict())
+    else:
+        return jsonify({"error": "Game not initialized"}), 500
+
+if __name__ == '__main__':
+    if game:
+        print("Starting Flask server with UnoGame initialized.")
+        app.run(debug=True, host='0.0.0.0', port=5000)
+    else:
+        print("Flask server cannot start, UnoGame failed to initialize.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 black==25.1.0
     # via based-uno (pyproject.toml)
+flask==3.0.3
+    # via based-uno (pyproject.toml)
 build==1.2.2.post1
     # via pip-tools
 cfgv==3.4.0

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export FLASK_APP=app.py
+export FLASK_ENV=development
+python -m flask run --host=0.0.0.0 --port=5000

--- a/uno_game/src/card.py
+++ b/uno_game/src/card.py
@@ -97,6 +97,16 @@ class Card:
         # Standard match: color or rank
         return self.color == other_card.color or self.rank == other_card.rank
 
+    def to_dict(self):
+        """Returns a dictionary representation of the card."""
+        return {
+            "color": self.color.name,
+            "rank": self.rank.name,
+            "value_str": str(self.rank), # For display like "7" or "SKIP"
+            "active_color": self.active_color.name if self.active_color else self.color.name,
+            "display_str": str(self),
+        }
+
 
 if __name__ == "__main__":
     # Test basic card creation


### PR DESCRIPTION
- Added Flask and created a basic web server in app.py.
- Implemented /api/game_state endpoint to return the current game status.
- Added to_dict() methods to UnoGame and Card classes for JSON serialization.
- Created run.sh to start the server.
- Updated README.md with instructions to run the server.