### PR TITLE
Implement single-player game against CPU opponents via web UI

### DIFF
--- a/uno_game/src/player.py
+++ b/uno_game/src/player.py
@@ -3,8 +3,9 @@ from .card import Card, Color, Rank  # Assuming card.py is in the same directory
 
 
 class Player:
-    def __init__(self, name: str):
+    def __init__(self, name: str, player_type: str = "HUMAN"):
         self.name: str = name
+        self.player_type: str = player_type  # HUMAN or CPU
         self.hand: List[Card] = []
 
         # Game-specific counters


### PR DESCRIPTION
This commit introduces the functionality for a single human player to play a game of Uno against CPU opponents using the existing web frontend.

Key changes include:
- Enhanced Player class and UnoGame initialization to support player types (HUMAN/CPU).
- Implemented CPU player decision-making logic within the UnoGame class (`get_cpu_action`).
- Refined API endpoints in `app.py`, particularly `/api/cpu_play_turn`, to use the new CPU logic and manage game flow.
- Updated frontend JavaScript (`script.js`) to automate CPU turns, handle sequential CPU play, and manage UI states for human vs. CPU actions.
- Improved UI prompts and structure in `script.js` for handling complex card actions (Rank 6, Swaps, Blue 3 discards).
- Ensured card styling in the frontend reflects card colors and types.